### PR TITLE
failing test

### DIFF
--- a/test/samples/misc.js
+++ b/test/samples/misc.js
@@ -19,3 +19,12 @@ const doubleQuotedString = "this is also \"escaped\"";
 const templateString = `the answer is ${answer}. This is a backtick: \``;
 
 const regex = /you can ignore\/[/]skip me, it's cool/;
+
+function calc (data) {
+  for (i = 0; i < num; i++)
+    something = item[i] / total * 100
+
+  for (i = 0; i < 4; i++) {
+    something = Math.round(totals[i] / total * 100)
+  }
+}

--- a/test/samples/misc.js
+++ b/test/samples/misc.js
@@ -1,4 +1,5 @@
 const answer = 42; // line comment
+const moarAnswer = (7*4)/(2/3)
 
 /*
   (•_•)


### PR DESCRIPTION
this test will fail in two ways:

```
> tippex@1.2.0 test /Users/kenny/Projects/tippex
> mocha --compilers js:babel-register



  1) "before all" hook

  0 passing (28ms)
  1 failing

  1)  "before all" hook:
     TypeError: state is not a function
      at Object.find (Users/kenny/Projects/tippex/src/index.js:137:9)
      at Context.<anonymous> (test/test.js:41:19)

```

the problem there is that the for-loop does not have brackets. I'll add them now and pretend the above bug does not exist. now it will incorrectly find a regex that's not there:

```
  12 passing (23ms)
  1 failing

  1) tippex find finds regular expressions:

      AssertionError: 2 == 1
      + expected - actual

      -2
      +1

      at Context.<anonymous> (test/test.js:91:11)


```
