### PR TITLE
Distinguish between regex and division

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ code = tippex.replace( code, importPattern, ( match, name, source ) => {
 ```
 
 
+## Known issues
+
+It's extremely difficult to distinguish between regular expression literals and division operators in certain edge cases at the lexical level. Fortunately, these cases are rare and generally somewhat contrived. If you encounter one in the wild, please raise an issue so we can try to accommodate it.
+
+
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 const keywords = /(case|delete|do|else|in|instanceof|new|return|throw|typeof|void)\s*$/;
-const punctuators = /(\{|\(|\[\.|;|,|<|>|<=|>=|==|!=|===|!==|\+|-|\*\%|<<|>>|>>>|&|\||\^|!|~|&&|\|\||\?|:|=|\+=|-=|\*=|%=|<<=|>>=|>>>=|&=|\|=|\^=|\/=|\/)\s*$/;
+const punctuators = /(^|\{|\(|\[\.|;|,|<|>|<=|>=|==|!=|===|!==|\+|-|\*\%|<<|>>|>>>|&|\||\^|!|~|&&|\|\||\?|:|=|\+=|-=|\*=|%=|<<=|>>=|>>>=|&=|\|=|\^=|\/=|\/)\s*$/;
 const ambiguous = /(\}|\)|\+\+|--)\s*$/;
-const counterparts = { '}': '{', ')': '(' };
 
 export function find ( str ) {
 	let quote;
@@ -180,10 +179,7 @@ function tokenClosesExpression ( substr, found ) {
 		if ( substr.slice( i - 2, i ) === 'if' || substr.slice( i - 5, i ) === 'while' ) return false;
 	}
 
-	else {
-		throw new Error( 'TODO handle }, ++ and -- tokens immediately followed by / character' );
-	}
-
+	// TODO handle }, ++ and -- tokens immediately followed by / character
 	return true;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,12 @@
+const keywords = /(case|delete|do|else|in|instanceof|new|return|throw|typeof|void)\s*$/;
+const punctuators = /(\{|\(|\[\.|;|,|<|>|<=|>=|==|!=|===|!==|\+|-|\*\%|<<|>>|>>>|&|\||\^|!|~|&&|\|\||\?|:|=|\+=|-=|\*=|%=|<<=|>>=|>>>=|&=|\|=|\^=|\/=|\/)\s*$/;
+const ambiguous = /(\}|\)|\+\+|--)\s*$/;
+const counterparts = { '}': '{', ')': '(' };
+
 export function find ( str ) {
 	let quote;
 	let escapedFrom;
+	let regexEnabled = true;
 	let stack = [];
 
 	let start;
@@ -8,7 +14,17 @@ export function find ( str ) {
 	let state = base;
 
 	function base ( char, i ) {
-		if ( char === '/' ) return start = i, slash;
+		if ( char === '/' ) {
+			// could be start of regex literal OR division punctuator. Solution via
+			// http://stackoverflow.com/questions/5519596/when-parsing-javascript-what-determines-the-meaning-of-a-slash/27120110#27120110
+			const substr = str.substr( 0, i );
+			if ( keywords.test( substr ) || punctuators.test( substr ) ) regexEnabled = true;
+			else if ( ambiguous.test( substr ) && !tokenClosesExpression( substr, found ) ) regexEnabled = true; // TODO save this determination for when it's necessary?
+			else regexEnabled = false;
+
+			return start = i, slash;
+		}
+
 		if ( char === '"' || char === "'" ) return start = i, quote = char, string;
 		if ( char === '`' ) return start = i, templateString;
 
@@ -21,8 +37,8 @@ export function find ( str ) {
 	function slash ( char ) {
 		if ( char === '/' ) return lineComment;
 		if ( char === '*' ) return blockComment;
-		if ( char === '[' ) return regexCharacter;
-		return regex;
+		if ( char === '[' ) return regexEnabled ? regexCharacter : base;
+		return regexEnabled ? regex : base;
 	}
 
 	function regex ( char, i ) {
@@ -137,6 +153,40 @@ export function find ( str ) {
 	return found;
 }
 
+function tokenClosesExpression ( substr, found ) {
+	substr = _erase( substr, found );
+
+	const token = ambiguous.exec( substr )[1];
+
+	if ( token === ')' ) {
+		let count = 0;
+		let i = substr.length;
+		while ( i-- ) {
+			if ( substr[i] === ')' ) {
+				count += 1;
+			}
+
+			if ( substr[i] === '(' ) {
+				count -= 1;
+				if ( count === 0 ) {
+					i -= 1;
+					break;
+				}
+			}
+		}
+
+		// if parenthesized expression is immediately preceded by `if`/`while`, it's not closing an expression
+		while ( /\s/.test( substr[i - 1] ) ) i -= 1;
+		if ( substr.slice( i - 2, i ) === 'if' || substr.slice( i - 5, i ) === 'while' ) return false;
+	}
+
+	else {
+		throw new Error( 'TODO handle }, ++ and -- tokens immediately followed by / character' );
+	}
+
+	return true;
+}
+
 function spaces ( count ) {
 	let spaces = '';
 	while ( count-- ) spaces += ' ';
@@ -154,7 +204,10 @@ const erasers = {
 
 export function erase ( str ) {
 	const found = find( str );
+	return _erase( str, found );
+}
 
+function _erase ( str, found ) {
 	let erased = '';
 	let charIndex = 0;
 

--- a/test/samples/misc.js
+++ b/test/samples/misc.js
@@ -19,3 +19,12 @@ const doubleQuotedString = "this is also \"escaped\"";
 const templateString = `the answer is ${answer}. This is a backtick: \``;
 
 const regex = /you can ignore\/[/]skip me, it's cool/;
+
+function calc (data) {
+  for (i = 0; i < num; i++)
+    something = item[i] / total * 100
+
+  for (i = 0; i < 4; i++) {
+    something = Math.round(totals[i] / total * 100)
+  }
+}

--- a/test/samples/misc.js
+++ b/test/samples/misc.js
@@ -21,6 +21,8 @@ const templateString = `the answer is ${answer}. This is a backtick: \``;
 
 const regex = /you can ignore\/[/]skip me, it's cool/;
 
+if ( a / b ) /foo/;
+
 function calc (data) {
   for (i = 0; i < num; i++)
     something = item[i] / total * 100

--- a/test/samples/misc.js
+++ b/test/samples/misc.js
@@ -1,4 +1,5 @@
 const answer = 42; // line comment
+const moarAnswer = (7*4)/(2/3)
 
 /*
   (•_•)

--- a/test/samples/regexDivisionAfter.js
+++ b/test/samples/regexDivisionAfter.js
@@ -1,0 +1,13 @@
+/   /;
+/   /;
+a
+/b/g;
+a/b/g;
+(a)/b/g;
+(a/b)/c;
+(a/b)/c/g;
+if (a)/ /g;
+if (a/b)/ /g;
+while (a)/ /g;
+while (a/b)/ /g;
+++/ /.abc;

--- a/test/samples/regexDivisionBefore.js
+++ b/test/samples/regexDivisionBefore.js
@@ -1,0 +1,13 @@
+/foo/;
+/foo/;
+a
+/b/g;
+a/b/g;
+(a)/b/g;
+(a/b)/c;
+(a/b)/c/g;
+if (a)/b/g;
+if (a/b)/c/g;
+while (a)/b/g;
+while (a/b)/c/g;
+++/b/.abc;

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import * as path from 'path';
 import { describe, it } from 'mocha';
 import * as assert from 'assert';
 import sms from 'source-map-support';
@@ -62,7 +61,7 @@ describe( 'tippex', () => {
 			const end = samples.misc.indexOf( 'cool/' ) + 5;
 			const regex = samples.misc.slice( start, end );
 
-			assert.equal( regexes.length, 1 );
+			assert.equal( regexes.length, 2 );
 			assert.deepEqual( regexes[0], {
 				start,
 				end,
@@ -160,6 +159,11 @@ describe( 'tippex', () => {
 		it( 'erases normal strings', () => {
 			assert.equal( erased.indexOf( 'trying to escape' ), -1 );
 			assert.equal( erased.indexOf( 'escaped' ), -1 );
+		});
+
+		it( 'handles tricky regex/division cases', () => {
+			const erased = tippex.erase( samples.regexDivisionBefore );
+			assert.equal( erased, samples.regexDivisionAfter );
 		});
 	});
 


### PR DESCRIPTION
Follow-up to #2 (and maybe #1?). [This SO answer](http://stackoverflow.com/questions/5519596/when-parsing-javascript-what-determines-the-meaning-of-a-slash/27120110#27120110) neatly explains the difficulty of distinguishing between regex literals and the division operator. The first part is fairly easy – just need to check for keywords and punctuators immediately preceding the `/`. The second is a little trickier – dealing with ambiguous tokens (`}`, `)`, `++`, `--`).

In the case of `)` we just need to backtrack until we find the corresponding opening paren, and see if it follows `if` or `while`, which is relatively straightforward when we know where the preceding strings and comments are. Ditto with `}` and `function`. Not sure about `++`/`--` yet.
