### PR TITLE
Handle trailing asterisk pairs in block comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ export function find ( str ) {
 			return base;
 		}
 
-		return blockComment;
+		return blockComment( char );
 	}
 
 	for ( let i = 0; i < str.length; i += 1 ) {

--- a/test/test.js
+++ b/test/test.js
@@ -164,6 +164,11 @@ describe( 'tippex', () => {
 			assert.equal( erased.indexOf( 'escaped' ), -1 );
 		});
 
+		it( 'handles classes', () => {
+			const erased = tippex.erase( '/* double trailing asterisks **/' );
+			assert.equal( erased, '                                ' );
+		});
+
 		it( 'handles tricky regex/division cases', () => {
 			const erased = tippex.erase( samples.regexDivisionBefore );
 			assert.equal( erased, samples.regexDivisionAfter );


### PR DESCRIPTION
Tippex crashes with `TypeError: state is not a function`.

Minimal reproducing example: `/***/`
